### PR TITLE
Add a log statement to ease debugging of errors

### DIFF
--- a/core/components/mailchimpsubscribe/model/mailchimpsubscribe/mailchimpsubscribe.class.php
+++ b/core/components/mailchimpsubscribe/model/mailchimpsubscribe/mailchimpsubscribe.class.php
@@ -395,6 +395,9 @@ class MailChimpSubscribe
         }
         
         if ($result['status'] !== $subscribeStatus && $this->valideSubscription) {
+            // Log the detailed error so it's easier to debug problems
+            $this->modx->log(modX::LOG_LEVEL_ERROR, print_r($result, true));
+            
             $response = $result['title'] . ': '  . $result['detail'];
 
             $this->hook->addError(self::MC_ERROR_PH, $response);


### PR DESCRIPTION
Client received this message when trying to sign up:

```
Invalid Resource: The resource submitted could not be validated. For field-specific details, see the 'errors' array.
```

... but the `errors` array was being discarded. By logging the response, debugging issues became a lot easier. 